### PR TITLE
#24138 - Updated publish hooks

### DIFF
--- a/hooks/post_publish.py
+++ b/hooks/post_publish.py
@@ -179,14 +179,19 @@ class PostPublishHook(Hook):
 
         # rename script:
         nuke.root()["name"].setValue(new_path)
-    
+        
         # update write nodes:
         write_node_app = tank.platform.current_engine().apps.get("tk-nuke-writenode")
         if write_node_app:
-            progress_cb(50, "Resetting render paths for write nodes")
-            # reset render paths for all write nodes:
-            for wn in write_node_app.get_write_nodes():
-                 write_node_app.reset_node_render_path(wn)
+            # only need to forceably reset the write node render paths if the app version
+            # is less than or equal to v0.1.11
+            from distutils.version import LooseVersion
+            if (write_node_app.version != "Undefined" 
+                and LooseVersion(write_node_app.version) <= LooseVersion("v0.1.11")):
+                progress_cb(50, "Resetting render paths for write nodes")
+                # reset render paths for all write nodes:
+                for wn in write_node_app.get_write_nodes():
+                    write_node_app.reset_node_render_path(wn)
                         
         # save the script:
         progress_cb(75, "Saving the scene file")

--- a/hooks/scan_scene_tk-nuke.py
+++ b/hooks/scan_scene_tk-nuke.py
@@ -75,10 +75,12 @@ class ScanSceneHook(Hook):
                 # use app to get node details:
                 name = app.get_node_name(write_node)
                 profile_name = app.get_node_profile_name(write_node)
+                is_disabled = write_node.knob("disable").value()
                 
                 items.append({"name":"Shotgun Write Node: %s" % name,
                               "type":"write_node",
                               "description":"Render Profile: %s" % profile_name,
+                              "selected":not is_disabled,
                               "other_params":{"node":write_node}})
                  
         return items


### PR DESCRIPTION
They now work with the new write node app that no longer requires the node paths to be reset after publishing.  Reset is left in for backwards compatibility with older versions of the app.
