### PR TITLE
Changed the functionality of hooks for secondary outputs

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -67,23 +67,6 @@ configuration:
                      The hook is responsible for the entire publish process and should
                      ensure to register the publish with Shotgun.
 
-    hook_secondary_pre_publish:
-        type: hook
-        parameters: [tasks, progress_cb]
-        default_value: "secondary_pre_publish_{engine_name}"
-        description: Specify the hook that will run before the publish.  This hook can be
-                     used to perform any validaiton on the secondary tasks that are passed 
-                     in to ensure that they are ready to be published.
-        
-    hook_secondary_publish:
-        type: hook
-        parameters: [tasks, work_template, comment, thumbnail_path, sg_task, primary_task, primary_publish_path, progress_cb]
-        default_value: "secondary_publish_{engine_name}"
-        description: Specify the hook that will be used to do the publish.  This hook is 
-                     passed a list of secondary tasks that are to be published.
-                     The hook is responsible for the entire publish process and should
-                     ensure it registers the published files with Shotgun
-
     hook_post_publish:
         type: hook
         parameters: [work_template, primary_task, secondary_tasks, progress_cb]
@@ -167,12 +150,37 @@ configuration:
                                  files for this output with Shotgun.  
                                  If set to '' then this must be determined within the publish hook.
                     allows_empty: True
+
                 publish_template:
                     type: template
                     fields: context, * 
                     allows_empty: True
                     description: Template used to locate published files within the file system.
                                  If null then this must be determined within the publish hook.
+
+                hook_scan_scene: 
+                    type: hook
+                    parameters: []
+                    description: Specify a hook to scan for items to publish.  
+                                 The hook should return a list dictionaries that represent the items
+                                 to be published.
+
+                hook_secondary_pre_publish:
+                    type: hook
+                    parameters: [tasks, progress_cb]
+                    description: Specify the hook that will run before the publish.  This hook can be
+                                 used to perform any validaiton on the secondary tasks that are passed 
+                                 in to ensure that they are ready to be published.
+                    
+                hook_secondary_publish:
+                    type: hook
+                    parameters: [tasks, work_template, comment, thumbnail_path, sg_task, primary_task, primary_publish_path, progress_cb]
+                    description: Specify the hook that will be used to do the publish.  This hook is 
+                                 passed a list of secondary tasks that are to be published.
+                                 The hook is responsible for the entire publish process and should
+                                 ensure it registers the published files with Shotgun
+
+
 
         decription: Specify all other outputs that are supported.
                     All non-primary items returned from the scan scene hook must match
@@ -203,7 +211,7 @@ description: "Provides UI and functionality to publish files to Shotgun."
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.14.58"
+requires_core_version: "v0.14.11"
 requires_engine_version: 
 
 # this app works in all engines - it does not contain 
@@ -212,5 +220,5 @@ supported_engines:
 
 # the frameworks required to run this app
 frameworks:
-    - {"name": "tk-framework-widget", "version": "v0.2.x"}    
+    - {"name": "tk-framework-widget", "version": "v0.1.19"}
     

--- a/python/tk_multi_publish/output.py
+++ b/python/tk_multi_publish/output.py
@@ -65,6 +65,18 @@ class PublishOutput(object):
     @property
     def publish_template(self):
         return self._publish_template
+
+    @property
+    def hook_scan_scene(self):
+        return self._raw_fields["hook_scan_scene"]
+
+    @property
+    def hook_secondary_pre_publish(self):
+        return self._raw_fields["hook_secondary_pre_publish"]
+
+    @property
+    def hook_secondary_publish(self):
+        return self._raw_fields["hook_secondary_publish"]
         
     @property
     def selected(self):

--- a/python/tk_multi_publish/publish.py
+++ b/python/tk_multi_publish/publish.py
@@ -315,8 +315,18 @@ class PublishHandler(object):
         """
         Find the list of 'items' to publish
         """
+
         # find the items:
         items = [Item(item) for item in self._app.execute_hook("hook_scan_scene")]
+
+        for output in self._secondary_outputs:
+            # execute scan scene hooks for each output
+            # and append the resulted items to items
+            hook_expression = '{config}/' + output.hook_scan_scene + '.py'
+            method_name = "execute"
+            for item in self._app.execute_hook_expression(hook_expression, method_name):
+                obj_item = Item(item)
+                items.append(obj_item)
     
         # validate that only one matches the primary type
         # and that all items are valid:
@@ -349,10 +359,28 @@ class PublishHandler(object):
 
         # do pre-publish of secondary tasks:
         hook_tasks = [task.as_dictionary() for task in secondary_tasks]
+
+        '''
         pp_results = self._app.execute_hook("hook_secondary_pre_publish",  
                                             tasks=hook_tasks, 
                                             work_template = self._work_template,
                                             progress_cb=progress_cb)
+        '''
+        pp_results = []
+
+
+        for output in self._secondary_outputs:
+            # execute secondary_pre_publish hooks for each output
+            # and extend the results to pp_results
+            hook_expression = '{config}/' + output.hook_secondary_pre_publish + '.py'
+            method_name = "execute"
+            hook_results = self._app.execute_hook_expression(hook_expression, method_name,
+                                                  tasks=hook_tasks, 
+                                                  work_template = self._work_template,
+                                                  progress_cb=progress_cb)
+            pp_results.extend(hook_results)
+
+
         
         # push any errors back to tasks:
         result_index = {}
@@ -396,6 +424,7 @@ class PublishHandler(object):
         """
         # do publish of secondary tasks:            
         hook_tasks = [task.as_dictionary() for task in secondary_tasks]
+        '''
         p_results = self._app.execute_hook("hook_secondary_publish",  
                                              tasks=hook_tasks, 
                                              work_template = self._work_template,
@@ -405,6 +434,25 @@ class PublishHandler(object):
                                              primary_task = primary_task.as_dictionary(),
                                              primary_publish_path=primary_publish_path,
                                              progress_cb=progress_cb)
+        '''
+        p_results = []
+
+        for output in self._secondary_outputs:
+            # execute secondary_publish hooks for each output
+            # and extend the results to p_results
+            hook_expression = '{config}/' + output.hook_secondary_publish + '.py'
+            method_name = "execute"
+            hook_results = self._app.execute_hook_expression(hook_expression, method_name,
+                                                 tasks=hook_tasks, 
+                                                 work_template = self._work_template,
+                                                 comment = comment,
+                                                 thumbnail_path = thumbnail_path,
+                                                 sg_task = sg_task,
+                                                 primary_task = primary_task.as_dictionary(),
+                                                 primary_publish_path=primary_publish_path,
+                                                 progress_cb=progress_cb)
+            p_results.extend(hook_results)
+
         
         # push any errors back to tasks:
         result_index = {}


### PR DESCRIPTION
Now they are not required in the general settings but in each of the specified secondary outputs. This allows to separate the code for each secondary output and helps in better organization and management of code in cases where we have a lot of secondary outputs.

For now I can't find a way to execute the hooks from inside the secondary outputs list in a cleaner way, so I used the execute_hook_expression method instead. Maybe you could help me with a more elegant solution...