### PR TITLE
Fixed #27945 - Mari would sometimes crash when flattening a channel.

### DIFF
--- a/hooks/scan_scene_tk-mari.py
+++ b/hooks/scan_scene_tk-mari.py
@@ -71,12 +71,15 @@ class ScanSceneHook(Hook):
 
                 params = {"geo":geo.name(), "channel":channel.name()}
 
+                # find all publishable layers:
+                publishable_layers = self.find_publishable_layers_r(channel.layerList())
+                if not publishable_layers:
+                    # no layers to publish!
+                    continue
+
                 # add item for whole flattened channel:
                 item_name = "%s, %s" % (geo.name(), channel.name())
                 items.append({"type":"channel", "name":item_name, "other_params":params})
-                
-                # find all publishable layers:
-                publishable_layers = self.find_publishable_layers_r(channel.layerList())
                 
                 # add item for each publishable layer:
                 found_layer_names = set()

--- a/hooks/secondary_publish_tk-mari.py
+++ b/hooks/secondary_publish_tk-mari.py
@@ -233,21 +233,23 @@ class PublishHook(Hook):
                 # us but happened 100% for the client!
                 layer = layers[0]
                 layer.exportImages(output_path)
-            elif len(layers) > 0:
+            elif len(layers) > 1:
                 # flatten layers in the channel and publish the flattened layer:
                 # remember the current channel:
                 current_channel = geo.currentChannel()
                 # duplicate the channel so we don't operate on the original:
                 duplicate_channel = geo.createDuplicateChannel(channel)
-                # flatten it into a single layer:
-                flattened_layer = duplicate_channel.flatten()
-                # export the images for it:
-                flattened_layer.exportImages(output_path)
-                # set the current channel back - not doing this will result in Mari crashing
-                # when the duplicated channel is removed!
-                geo.setCurrentChannel(current_channel)
-                # remove the duplicate channel, destroying the channel and the flattened layer:
-                geo.removeChannel(duplicate_channel, geo.DESTROY_ALL)
+                try:
+                    # flatten it into a single layer:
+                    flattened_layer = duplicate_channel.flatten()
+                    # export the images for it:
+                    flattened_layer.exportImages(output_path)
+                finally:
+                    # set the current channel back - not doing this will result in Mari crashing
+                    # when the duplicated channel is removed!
+                    geo.setCurrentChannel(current_channel)
+                    # remove the duplicate channel, destroying the channel and the flattened layer:
+                    geo.removeChannel(duplicate_channel, geo.DESTROY_ALL)
             else:
                 raise TankError("Channel '%s' doesn't appear to have any layers!" % channel.name())            
 

--- a/hooks/secondary_publish_tk-mari.py
+++ b/hooks/secondary_publish_tk-mari.py
@@ -223,21 +223,33 @@ class PublishHook(Hook):
             progress_cb(50, "Exporting layer")
             layer.exportImages(output_path)
         else:
-            # flatten layers in the channel and publish the flattened layer:
+            # publish the entire channel, flattened
             progress_cb(50, "Exporting channel")
-            # remember the current channel:
-            current_channel = geo.currentChannel()
-            # duplicate the channel so we don't operate on the original:
-            duplicate_channel = geo.createDuplicateChannel(channel)
-            # flatten it into a single layer:
-            flattened_layer = duplicate_channel.flatten()
-            # export the images for it:
-            flattened_layer.exportImages(output_path)
-            # set the current channel back - not doing this will result in Mari crashing
-            # when the duplicated channel is removed!
-            geo.setCurrentChannel(current_channel)
-            # remove the duplicate channel, destroying the channel and the flattened layer:
-            geo.removeChannel(duplicate_channel, geo.DESTROY_ALL)
+            layers = channel.layerList()
+            if len(layers) == 1:
+                # only one layer so just publish it:
+                # Note - this works around an issue that was reported (#27945) where flattening a channel
+                # with only a single layer would cause Mari to crash - this bug was not reproducible by
+                # us but happened 100% for the client!
+                layer = layers[0]
+                layer.exportImages(output_path)
+            elif len(layers) > 0:
+                # flatten layers in the channel and publish the flattened layer:
+                # remember the current channel:
+                current_channel = geo.currentChannel()
+                # duplicate the channel so we don't operate on the original:
+                duplicate_channel = geo.createDuplicateChannel(channel)
+                # flatten it into a single layer:
+                flattened_layer = duplicate_channel.flatten()
+                # export the images for it:
+                flattened_layer.exportImages(output_path)
+                # set the current channel back - not doing this will result in Mari crashing
+                # when the duplicated channel is removed!
+                geo.setCurrentChannel(current_channel)
+                # remove the duplicate channel, destroying the channel and the flattened layer:
+                geo.removeChannel(duplicate_channel, geo.DESTROY_ALL)
+            else:
+                raise TankError("Channel '%s' doesn't appear to have any layers!" % channel.name())            
 
         # register the publish:
         progress_cb(80, "Registering the publish")


### PR DESCRIPTION
- This fix implements a workaround to stop Mari from crashing when trying to flatten a channel containing a single layer during publish.