### PR TITLE
#33333 Adds the ability to publish tk-houdini-alembicnode and tk-houdini-mantranode outptus

### DIFF
--- a/hooks/primary_publish.py
+++ b/hooks/primary_publish.py
@@ -98,7 +98,7 @@ class PrimaryPublishHook(Hook):
             return self._do_maya_publish(*args)
         elif engine_name == "tk-motionbuilder":
             return self._do_motionbuilder_publish(*args)
-        elif engine_name == "tk-hiero"
+        elif engine_name == "tk-hiero":
             return self._do_hiero_publish(*args)
         elif engine_name == "tk-nuke":
             return self._do_nuke_publish(*args)

--- a/hooks/scan_scene_tk-houdini.py
+++ b/hooks/scan_scene_tk-houdini.py
@@ -70,7 +70,7 @@ class ScanSceneHook(Hook):
         return items
 
     def _get_alembic_items(self):
-        """Scan the file for tk alembic nodes with already exported caches."""
+        """Scan the file for tk alembic nodes to potentially publish."""
 
         app = self.parent
         
@@ -116,7 +116,7 @@ class ScanSceneHook(Hook):
         return alembic_items
 
     def _get_rendered_image_items(self):
-        """Scan the file for tk mantra nodes with already rendered images."""
+        """Scan the file for tk mantra nodes to potentially publish."""
 
         app = self.parent
 

--- a/hooks/scan_scene_tk-houdini.py
+++ b/hooks/scan_scene_tk-houdini.py
@@ -97,11 +97,16 @@ class ScanSceneHook(Hook):
             out_path_parm = tk_alembic_node.parm("filename")
             out_path = out_path_parm.menuLabels()[out_path_parm.eval()]
 
+            # only select the item if the path exists and the node is not
+            # bypassed
+            should_select = out_path and os.path.exists(out_path) and \
+                not is_bypassed
+
             alembic_items.append({
                 "name": "Shotgun Alembic Node: %s" % (tk_alembic_node.name(),),
                 "type": "alembic_cache",
                 "description": "Full Path: %s" % (tk_alembic_node.path(),),
-                "selected": not is_bypassed,
+                "selected": should_select,
                 "other_params": {
                     "path": out_path,
                     "node": tk_alembic_node,
@@ -162,11 +167,15 @@ class ScanSceneHook(Hook):
                 output_template, {"SEQ": "FORMAT: %d", "version": cur_version}
             )
 
+            # only select the item if the output path exists and the node is
+            # not bypassed.
+            should_select = len(paths) == 1 and not is_bypassed
+
             render_items.append({
                 "type": "rendered_image",
                 "name": "Shotgun Mantra Node: %s" % (tk_mantra_node.name(),),
                 "description": "Full Path: %s" % (tk_mantra_node.path(),),
-                "selected": not is_bypassed,
+                "selected": should_select,
                 "other_params": {
                     "paths": paths,
                     "node": tk_mantra_node,

--- a/hooks/scan_scene_tk-houdini.py
+++ b/hooks/scan_scene_tk-houdini.py
@@ -32,22 +32,17 @@ class ScanSceneHook(Hook):
                                     one of the outputs in the configuration and is
                                     used to determine the outputs that should be
                                     published for the item
-
                             name:   String
                                     Name to use for the item in the UI
-
                             description:    String
                                             Description of the item to use in the UI
-
                             selected:       Bool
                                             Initial selected state of item in the UI.
                                             Items are selected by default.
-
                             required:       Bool
                                             Required state of item in the UI.  If True then
                                             item will not be deselectable.  Items are not
                                             required by default.
-
                             other_params:   Dictionary
                                             Optional dictionary that will be passed to the
                                             pre-publish and publish hooks
@@ -65,4 +60,115 @@ class ScanSceneHook(Hook):
 
         # create the primary item - this will match the primary output 'scene_item_type':
         items.append({"type": "work_file", "name": name})
+
+        # look for alembic caches to publish
+        items.extend(self._get_exported_alembic_items())
+
+        # look for rendered images to publish
+        items.extend(self._get_rendered_image_items())
+
         return items
+
+    def _get_exported_alembic_items(self):
+        """Scan the file for tk alembic nodes with already exported caches."""
+
+        app = self.parent
+        
+        # see if the alembicnode app is installed
+        alembic_app = app.engine.apps.get("tk-houdini-alembicnode", None)
+        if not alembic_app:
+            app.log_info(
+                "Will not attempt to scan for alembic caches."
+                "The 'tk-houdini-alembicnode' app is not installed."
+            )
+            return []
+
+        # get all the tk alembic nodes in the scene
+        tk_alembic_nodes = hou.nodeType(hou.ropNodeTypeCategory(),
+            "sgtk_alembic").instances()
+
+        alembic_items = []
+
+        # for each tk alembic node, see if the output file has been 
+        # created on disk. The node will have already evaluated the 
+        # all th fields, so current version should be correct.
+        for tk_alembic_node in tk_alembic_nodes:
+            out_path_parm = tk_alembic_node.parm("filename")
+            out_path = out_path_parm.menuLabels()[out_path_parm.eval()]
+
+            if os.path.exists(out_path):
+                alembic_items.append({
+                    "type": "alembic_cache",
+                    "name": tk_alembic_node.name(),
+                    "other_params": {'path': out_path},
+                })
+
+        return alembic_items
+
+    def _get_rendered_image_items(self):
+        """Scan the file for tk mantra nodes with already rendered images."""
+
+        app = self.parent
+
+        # see if the mantranode app is installed
+        mantra_app = app.engine.apps.get("tk-houdini-mantranode", None)
+        if not mantra_app:
+            app.log_info(
+                "Will not attempt to scan for rendered images."
+                "The 'tk-houdini-mantranode' app is not installed."
+            )
+            return []
+
+        # find all the tk mantra nodes
+        tk_mantra_nodes = hou.nodeType(hou.ropNodeTypeCategory(),
+            "sgtk_mantra").instances()
+
+        # get the current version from the work file
+        work_template = mantra_app.get_template("work_file_template")
+        scene_name = str(hou.hipFile.name())
+        scene_path = os.path.abspath(scene_name)
+        fields = work_template.get_fields(scene_path)
+        cur_version = fields["version"]
+
+        # get the output_profiles for the app
+        output_profiles = {}
+        for output_profile in mantra_app.get_setting("output_profiles"):
+            name = output_profile["name"]
+            output_profiles[name] = output_profile
+
+        render_items = []
+
+        # for each mantra node, see which output profile is selected.
+        # get the template for the selected profile and see if there are 
+        # any images on disk matching the pattern. if so, add them to the
+        # list of rendered items to be returned.
+        for tk_mantra_node in tk_mantra_nodes:
+            output_profile_parm = tk_mantra_node.parm("sgtk_output_profile")
+            output_profile_name = \
+                output_profile_parm.menuLabels()[output_profile_parm.eval()]
+            output_profile = output_profiles[output_profile_name]
+            output_template = mantra_app.get_template_by_name(
+                output_profile["output_render_template"])
+
+            paths = mantra_app.engine.tank.abstract_paths_from_template(
+                    output_template, {"SEQ": "FORMAT: %d", "version": cur_version})
+
+            if not paths:
+                continue
+
+            if len(paths) == 1:
+                if paths:
+                    render_items.append({
+                        "type": "rendered_image",
+                        "name": tk_mantra_node.name(),
+                        "other_params": {'path': paths[0]},
+                    })
+            else:
+                app.log_warning(
+                    "Found multiple potential rendered image paths for "
+                    "mantra node '%s'. Skipping these paths:\n  '%s'" % 
+                    (tk_mantra_node.name(), "\n  ".join(paths))
+                )
+    
+        return render_items
+

--- a/hooks/secondary_pre_publish_tk-houdini.py
+++ b/hooks/secondary_pre_publish_tk-houdini.py
@@ -115,7 +115,8 @@ class PrePublishHook(Hook):
         node = item["other_params"]["node"]
         path = item["other_params"]["path"]
         if not os.path.exists(path):
-            errors.append("No cache exists to be published!")
+            errors.append(
+                "No alembic cache has been written to disk for this node.")
         
         # finally return any errors
         return errors    

--- a/hooks/secondary_pre_publish_tk-houdini.py
+++ b/hooks/secondary_pre_publish_tk-houdini.py
@@ -50,7 +50,6 @@ class PrePublishHook(Hook):
                                     progress_cb(percentage, msg)
                                      
                                 to report progress to the UI
-
         :param user_data:       A dictionary containing any data shared by other hooks run prior to
                                 this hook. Additional data may be added to this dictionary that will
                                 then be accessible from user_data in any hooks run after this one.
@@ -82,12 +81,14 @@ class PrePublishHook(Hook):
             # report progress:
             progress_cb(0, "Validating", task)
 
-            # pre-publish item here, e.g.
-            #if output["name"] == "foo":
-            #    ...
-            #else:
-            # don't know how to publish this output types!
-            errors.append("Don't know how to publish this item!")
+            # pre-publish alembic_cache output
+            if output["name"] == "alembic_cache":
+                errors.extend(self.__validate_item_for_alembic_cache_publish(item))
+            elif output["name"] == "rendered_image":
+                errors.extend(self.__validate_item_for_rendered_image_publish(item))
+            else:
+                # don't know how to publish this output types!
+                errors.append("Don't know how to publish this item!")
 
             # if there is anything to report then add to result
             if len(errors) > 0:
@@ -97,3 +98,34 @@ class PrePublishHook(Hook):
             progress_cb(100)
 
         return results
+
+    def __validate_item_for_alembic_cache_publish(self, item):
+        """
+        Validate that the item is valid to be exported to an alembic cache.
+        
+        :param item:    The item to validate
+        :returns:       A list of any errors found during validation that should be reported
+                        to the artist
+        """
+    
+        # validate the exported alembic cache and add any errors found here
+        errors = []
+        
+        # finally return any errors
+        return errors    
+    
+    def __validate_item_for_rendered_image_publish(self, item):
+        """
+        Validate that the item is valid to be exported as rendered images.
+        
+        :param item:    The item to validate
+        :returns:       A list of any errors found during validation that should be reported
+                        to the artist
+        """
+    
+        # validate the exported rendered images and add any errors found here
+        errors = []
+        
+        # finally return any errors
+        return errors    
+

--- a/hooks/secondary_pre_publish_tk-houdini.py
+++ b/hooks/secondary_pre_publish_tk-houdini.py
@@ -8,8 +8,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from tank import Hook
+import os
 
+from tank import Hook
 
 class PrePublishHook(Hook):
     """
@@ -110,6 +111,11 @@ class PrePublishHook(Hook):
     
         # validate the exported alembic cache and add any errors found here
         errors = []
+
+        node = item["other_params"]["node"]
+        path = item["other_params"]["path"]
+        if not os.path.exists(path):
+            errors.append("No cache exists to be published!")
         
         # finally return any errors
         return errors    
@@ -126,6 +132,19 @@ class PrePublishHook(Hook):
         # validate the exported rendered images and add any errors found here
         errors = []
         
+        node = item["other_params"]["node"]
+        paths = item["other_params"]["paths"]
+        if not paths:
+            errors.append(
+                "No rendered images found for node '%s'." % (node.path(),)
+            )   
+        elif len(paths) > 1:
+            errors.append(
+                "Found multiple potential rendered image paths for node '%s'." 
+                "Skipping these paths:\n  '%s'" %
+                (node.path(), "\n  ".join(paths))
+            )
+
         # finally return any errors
         return errors    
 

--- a/hooks/secondary_publish_tk-houdini.py
+++ b/hooks/secondary_publish_tk-houdini.py
@@ -8,6 +8,11 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+import os
+
+import hou
+
+import tank
 from tank import Hook
 
 
@@ -69,7 +74,6 @@ class PublishHook(Hook):
         :param primary_task:            The primary task that was published by the primary publish hook.  Passed
                                         in here for reference.  This is a dictionary in the same format as the
                                         secondary tasks above.
-
         :param user_data:               A dictionary containing any data shared by other hooks run prior to
                                         this hook. Additional data may be added to this dictionary that will
                                         then be accessible from user_data in any hooks run after this one.
@@ -101,12 +105,38 @@ class PublishHook(Hook):
             # report progress:
             progress_cb(0, "Publishing", task)
 
-            # publish item here, e.g.
-            #if output["name"] == "foo":
-            #    ...
-            #else:
-            # don't know how to publish this output types!
-            errors.append("Don't know how to publish this item!")
+            # publish alembic_cache output
+            if output["name"] == "alembic_cache":
+                try:
+                   self.__publish_alembic_cache(
+                        item,
+                        output,
+                        work_template,
+                        primary_publish_path,
+                        sg_task,
+                        comment,
+                        thumbnail_path,
+                        progress_cb,
+                    )
+                except Exception, e:
+                    errors.append("Publish failed - %s" % e)
+            elif output["name"] == "rendered_image":
+                try:
+                    self.__publish_rendered_images(
+                        item,
+                        output,
+                        work_template,
+                        primary_publish_path,
+                        sg_task,
+                        comment,
+                        thumbnail_path,
+                        progress_cb,
+                    )
+                except Exception, e:
+                    errors.append("Publish failed - %s" % e) 
+            else:
+                # don't know how to publish this output types!
+                errors.append("Don't know how to publish this item!")
 
             # if there is anything to report then add to result
             if len(errors) > 0:
@@ -116,3 +146,110 @@ class PublishHook(Hook):
             progress_cb(100)
 
         return results
+
+    def __publish_alembic_cache(self, item, output, work_template, primary_publish_path, 
+                                sg_task, comment, thumbnail_path, progress_cb):
+        """
+        Publish rendered images and register with Shotgun.
+        
+        :param item:                    The item to publish
+        :param output:                  The output definition to publish with
+        :param work_template:           The work template for the current scene
+        :param primary_publish_path:    The path to the primary published file
+        :param sg_task:                 The Shotgun task we are publishing for
+        :param comment:                 The publish comment/description
+        :param thumbnail_path:          The path to the publish thumbnail
+        :param progress_cb:             A callback that can be used to report progress
+        """
+
+        # determine the publish info to use
+        #
+        progress_cb(10, "Determining publish details")
+
+        # get the current scene path and extract fields from it
+        # using the work template:
+        scene_name = str(hou.hipFile.name())
+        scene_path = os.path.abspath(scene_name)
+        fields = work_template.get_fields(scene_path)
+        publish_version = fields["version"]
+        tank_type = output["tank_type"]
+
+        # this is pretty straight forward since the publish file(s) have
+        # already been created (rendered). We're really just populating the
+        # arguments to send to the sg publish file registration below.
+        publish_name = item["name"]
+
+        # we already determined the path in the scan_scene code. so just 
+        # pull it from that dictionary.
+        other_params = item["other_params"]
+        publish_path = other_params["path"]
+
+        # register the publish:
+        progress_cb(75, "Registering the publish")        
+        args = {
+            "tk": self.parent.tank,
+            "context": self.parent.context,
+            "comment": comment,
+            "path": publish_path,
+            "name": publish_name,
+            "version_number": publish_version,
+            "thumbnail_path": thumbnail_path,
+            "task": sg_task,
+            "dependency_paths": [primary_publish_path],
+            "published_file_type": tank_type
+        }
+        tank.util.register_publish(**args)
+    
+    def __publish_rendered_images(self, item, output, work_template, primary_publish_path, 
+                                  sg_task, comment, thumbnail_path, progress_cb):
+        """
+        Publish rendered images and register with Shotgun.
+        
+        :param item:                    The item to publish
+        :param output:                  The output definition to publish with
+        :param work_template:           The work template for the current scene
+        :param primary_publish_path:    The path to the primary published file
+        :param sg_task:                 The Shotgun task we are publishing for
+        :param comment:                 The publish comment/description
+        :param thumbnail_path:          The path to the publish thumbnail
+        :param progress_cb:             A callback that can be used to report progress
+        """
+
+        # determine the publish info to use
+        #
+        progress_cb(10, "Determining publish details")
+
+        # get the current scene path and extract fields from it
+        # using the work template:
+        scene_name = str(hou.hipFile.name())
+        scene_path = os.path.abspath(scene_name)
+        fields = work_template.get_fields(scene_path)
+        publish_version = fields["version"]
+        tank_type = output["tank_type"]
+
+        # this is pretty straight forward since the publish file(s) have
+        # already been created (rendered). We're really just populating the
+        # arguments to send to the sg publish file registration below.
+        publish_name = item["name"]
+
+        # we already determined the path in the scan_scene code. so just 
+        # pull it from that dictionary.
+        other_params = item["other_params"]
+        publish_path = other_params["path"]
+
+        # register the publish:
+        progress_cb(75, "Registering the publish")        
+        args = {
+            "tk": self.parent.tank,
+            "context": self.parent.context,
+            "comment": comment,
+            "path": publish_path,
+            "name": publish_name,
+            "version_number": publish_version,
+            "thumbnail_path": thumbnail_path,
+            "task": sg_task,
+            "dependency_paths": [primary_publish_path],
+            "published_file_type": tank_type
+        }
+        tank.util.register_publish(**args)
+        

--- a/hooks/secondary_publish_tk-houdini.py
+++ b/hooks/secondary_publish_tk-houdini.py
@@ -13,7 +13,7 @@ import os
 import hou
 
 import tank
-from tank import Hook
+from tank import Hook, TankError
 
 
 class PublishHook(Hook):
@@ -183,6 +183,12 @@ class PublishHook(Hook):
         # pull it from that dictionary.
         other_params = item["other_params"]
         publish_path = other_params["path"]
+        node = other_params["node"]
+
+        if not os.path.exists(publish_path):
+            raise TankError(
+                "No rendered images found for node '%s'." % (node.path(),)
+            )
 
         # register the publish:
         progress_cb(75, "Registering the publish")        
@@ -235,7 +241,21 @@ class PublishHook(Hook):
         # we already determined the path in the scan_scene code. so just 
         # pull it from that dictionary.
         other_params = item["other_params"]
-        publish_path = other_params["path"]
+        paths = other_params["paths"]
+        node = other_params["node"]
+
+        if not paths:
+            raise TankError(
+                "No rendered images found for node '%s'." % (node.path(),)
+            )   
+        elif len(paths) > 1:
+            raise TankError(
+                "Found multiple potential rendered image paths for node '%s'." 
+                "Skipping these paths:\n  '%s'" %
+                (node.path(), "\n  ".join(paths))
+            )
+
+        publish_path = paths[0]
 
         # register the publish:
         progress_cb(75, "Registering the publish")        

--- a/hooks/secondary_publish_tk-houdini.py
+++ b/hooks/secondary_publish_tk-houdini.py
@@ -150,7 +150,7 @@ class PublishHook(Hook):
     def __publish_alembic_cache(self, item, output, work_template, primary_publish_path, 
                                 sg_task, comment, thumbnail_path, progress_cb):
         """
-        Publish rendered images and register with Shotgun.
+        Publish an alembic cache and register with Shotgun.
         
         :param item:                    The item to publish
         :param output:                  The output definition to publish with
@@ -175,7 +175,7 @@ class PublishHook(Hook):
         tank_type = output["tank_type"]
 
         # this is pretty straight forward since the publish file(s) have
-        # already been created (rendered). We're really just populating the
+        # already been written to disk. We're really just populating the
         # arguments to send to the sg publish file registration below.
         publish_name = item["name"]
 
@@ -187,7 +187,7 @@ class PublishHook(Hook):
 
         if not os.path.exists(publish_path):
             raise TankError(
-                "No rendered images found for node '%s'." % (node.path(),)
+                "No alembic caches found for node '%s'." % (node.path(),)
             )
 
         # register the publish:


### PR DESCRIPTION
These changes add secondary publish types of "alembic_cache" and "rendered_image" for houdini. The code checks for installation of tk-houdini-alembicnode and tk-houdini-mantranode and if found, looks on disk for exported/rendered files. If they exist, the user is prompted to publish those files. Validation of the files on disk is stubbed only. 

Should be noted that this alembic publishing differs from the maya implementation. This code expects the cache to exist on disk already where the maya alembic publish handles the export and publish together. Can discuss whether or not this implementation makes sense. 