### PR TITLE
#29170 Houdini scan scene now more in line with other DCCs re: save before pub

### DIFF
--- a/hooks/scan_scene_tk-houdini.py
+++ b/hooks/scan_scene_tk-houdini.py
@@ -55,7 +55,7 @@ class ScanSceneHook(Hook):
         """
         items = []
 
-        if hou.hipFile.hasUnsavedChanges():
+        if hou.hipFile.name() == "untitled.hip":
             raise TankError("Please save your file before Publishing")
 
         # get the main scene:


### PR DESCRIPTION
Houdini's scan scene was checking for unsaved changes. The other DCCs were simply checking to make sure the file had been saved previously (had non-default file name). This change makes sure the houdini session is does not have "untitled.hip" as the name. This is more similar to what the other DCC hooks do.