### PR TITLE
#41106: Cleans up active document handling for PSCC during pre-publish.

### DIFF
--- a/hooks/primary_pre_publish.py
+++ b/hooks/primary_pre_publish.py
@@ -481,6 +481,13 @@ class PrimaryPrePublishHook(Hook):
         Return the new version number that the scene should be
         up'd to after publish
         """
+        # If the path is unicode for some reason, we need to make sure
+        # we encode it as utf-8. This is sometimes an issue with file
+        # names that have non-english accent marks or special characters
+        # of some kind.
+        if isinstance(path, unicode):
+            path = path.encode("utf-8")
+
         errors = []
         
         progress_cb(25, "Validating work file")

--- a/hooks/primary_pre_publish.py
+++ b/hooks/primary_pre_publish.py
@@ -408,12 +408,10 @@ class PrimaryPrePublishHook(Hook):
         adobe = self.parent.engine.adobe
         
         progress_cb(0.0, "Validating current scene", task)
+
+        scene_file = adobe.get_active_document_path()
         
-        # get the current scene file:
-        try:
-            doc = adobe.app.activeDocument
-            scene_file = doc.fullName.fsName
-        except RuntimeError:
+        if not scene_file:
             return ["Unable to determine the active document's file path!"]
             
         # validate it:


### PR DESCRIPTION
Also sanitizes any unicode file paths that are received.