### PR TITLE
44075 thumbnail errors qafix

### DIFF
--- a/hooks/primary_publish.py
+++ b/hooks/primary_publish.py
@@ -11,7 +11,6 @@
 import os
 import uuid
 import tempfile
-import re
 
 import tank
 from tank import Hook

--- a/hooks/primary_publish.py
+++ b/hooks/primary_publish.py
@@ -1046,8 +1046,13 @@ class PrimaryPublishHook(Hook):
             
             try:
                 os.remove(jpeg_pub_path)
-            except:
-                pass
+            except Exception, e:
+                # Catch the error if unable to remove the temp file, but log the
+                # error for debug purpose.
+                self.parent.log_debug(
+                    "Failed to remove tmp jpeg file %s: %s" % (jpeg_pub_path, e)
+                )
+
         except Exception, e:
             # Do not prevent publishing to complete if an error happened when
             # creating a Version.

--- a/hooks/thumbnail.py
+++ b/hooks/thumbnail.py
@@ -17,6 +17,7 @@ import tank
 from tank import Hook
 from tank.platform.qt import QtCore
 
+
 class ThumbnailHook(Hook):
     """
     Hook that can be used to provide a pre-defined primary 
@@ -177,6 +178,10 @@ class ThumbnailHook(Hook):
         original_ruler_units = adobe.app.preferences.rulerUnits
         adobe.app.preferences.rulerUnits = adobe.Units.PIXELS
 
+        # disable dialogs unless they are error dialogs
+        original_dialog_mode = adobe.app.displayDialogs
+        adobe.app.displayDialogs = adobe.DialogModes.NO
+
         with self.parent.engine.context_changes_disabled():
             try:
                 active_doc = adobe.app.activeDocument
@@ -208,9 +213,12 @@ class ThumbnailHook(Hook):
                         thumb_height = max(min(int(doc_height * scale), doc_height), 1)
         
                 # get a path in the temp dir to use for the thumbnail:
-                jpg_pub_path = os.path.join(tempfile.gettempdir(), "%s_sgtk.jpg" % uuid.uuid4().hex)
+                jpg_pub_path = os.path.join(
+                    tempfile.gettempdir(), "%s_sgtk.jpg" % uuid.uuid4().hex
+                )
                 
-                # get a file object from Photoshop for this path and the current jpg save options:
+                # get a file object from Photoshop for this path and the current
+                # jpg save options:
                 thumbnail_file = adobe.File(jpg_pub_path)
                 jpg_options = adobe.JPEGSaveOptions
         
@@ -238,6 +246,8 @@ class ThumbnailHook(Hook):
             finally:
                 # set units back to original
                 adobe.app.preferences.rulerUnits = original_ruler_units
+                # Set dialog mode back to original.
+                adobe.app.displayDialogs = original_dialog_mode
 
     def _extract_legacy_photoshop_thumbnail(self):
         """

--- a/python/tk_multi_publish/publish.py
+++ b/python/tk_multi_publish/publish.py
@@ -170,6 +170,7 @@ class PublishHandler(object):
             # If the hook didn't return anything, don't try to build a QPixmap
             # from it.
             if thumb_path:
+                self._app.log_warning("Building a pixmap from %s" % thumb_path)
                 return QtGui.QPixmap(thumb_path)
         except Exception, e:
             logger.warning(

--- a/python/tk_multi_publish/publish.py
+++ b/python/tk_multi_publish/publish.py
@@ -170,8 +170,18 @@ class PublishHandler(object):
             # If the hook didn't return anything, don't try to build a QPixmap
             # from it.
             if thumb_path:
-                self._app.log_warning("Building a pixmap from %s" % thumb_path)
-                return QtGui.QPixmap(thumb_path)
+                pixmap = QtGui.QPixmap(thumb_path)
+                if pixmap.isNull():
+                    # Log debug information: sometimes the jpeg format is not
+                    # available from PySide, which can explain why no thumbnail
+                    # appears in the UI.
+                    self._app.log_debug(
+                        "Unable to build a pixmap from %s" % thumb_path
+                    )
+                    self._app.log_debug(
+                        "Supported formats are %s" % QtGui.QImageReader.supportedImageFormats()
+                    )
+                return pixmap
         except Exception, e:
             logger.warning(
                 "Unable to generate initial thumbnail because of the following error:"


### PR DESCRIPTION
This work fix problems when exporting Jpeg images, either as thumbnail or as images to create playable Version in SG.

* Added some debug logging when a valid QPixmap can't be build from a valid image path.
* Leverage tk-photoshopcc engine `generate_thumbnail` and `export_as_jpeg` , if available. 
* Issue some warnings if they are not, but keep going.