### PR TITLE
#42766 Ensures secondary outputs are rebuilt post context change.

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,7 +15,8 @@ Multi Publish
 
 import os
 import tank
-from tank import TankError
+
+
 
 class MultiPublish(tank.platform.Application):
 
@@ -84,4 +85,6 @@ class MultiPublish(tank.platform.Application):
         :param old_context: The sgtk.context.Context being switched from.
         :param new_context: The sgtk.context.Context being switched to.
         """
-        self._publish_handler.rebuild_primary_output()
+        self.log_debug("Context change. Rebuilding outputs...")
+        self._publish_handler.build_outputs()
+        self.log_debug("Outputs Rebuilt!")

--- a/python/tk_multi_publish/publish.py
+++ b/python/tk_multi_publish/publish.py
@@ -100,6 +100,16 @@ class PublishHandler(object):
                 PublishOutput(self._app, output)
             )
 
+    def rebuild_primary_output(self):
+        """
+        Deprecated in favor of `build_outputs()`. Left to ensure backward
+        compatibility for any client code that may be calling this.
+        :return:
+        """
+
+        # call the full output build
+        self.build_outputs()
+
     def show_publish_dlg(self):
         """
         Displays the publish dialog

--- a/python/tk_multi_publish/publish.py
+++ b/python/tk_multi_publish/publish.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import os
-import pprint
 import tempfile
 
 import tank
@@ -17,7 +16,6 @@ from tank import TankError
 from tank.platform.qt import QtCore, QtGui
 
 from .progress import TaskProgressReporter
-from .publish_form import PublishForm
 
 from .output import PublishOutput
 from .item import Item
@@ -37,17 +35,8 @@ class PublishHandler(object):
         self._app = app
 
         # load outputs from configuration:
-        primary_output_dict = {}
-        primary_output_dict["scene_item_type"] = self._app.get_setting("primary_scene_item_type")
-        primary_output_dict["display_name"] = self._app.get_setting("primary_display_name")
-        primary_output_dict["description"] = self._app.get_setting("primary_description")
-        primary_output_dict["icon"] = self._app.get_setting("primary_icon")
-        primary_output_dict["tank_type"] = self._app.get_setting("primary_tank_type")
-        primary_output_dict["publish_template"] = self._app.get_setting("primary_publish_template")
-        self._primary_output = PublishOutput(self._app, primary_output_dict, name=PublishOutput.PRIMARY_NAME, selected=True, required=True)
-        
-        self._secondary_outputs = [PublishOutput(self._app, output) for output in self._app.get_setting("secondary_outputs")]
-        
+        self.build_outputs()
+
         # validate the secondary outputs:
         unique_names = []
         for output in self._secondary_outputs:
@@ -75,11 +64,14 @@ class PublishHandler(object):
         """
         return self._app.get_template("template_work")
 
-    def rebuild_primary_output(self):
+    def build_outputs(self):
         """
-        Rebuilds the primary output object based on the parent app's current settings.
+        Rebuilds the primary and secondary outputs based on the parent app's
+        current settings.
         """
-        # load outputs from configuration:
+
+        # ---- load primary outputs from configuration:
+
         primary_output_dict = {}
         primary_output_dict["scene_item_type"] = self._app.get_setting("primary_scene_item_type")
         primary_output_dict["display_name"] = self._app.get_setting("primary_display_name")
@@ -88,6 +80,8 @@ class PublishHandler(object):
         primary_output_dict["tank_type"] = self._app.get_setting("primary_tank_type")
         primary_output_dict["publish_template"] = self._app.get_setting("primary_publish_template")
 
+        logger.debug("Primary Output: %s" % (primary_output_dict,))
+
         self._primary_output = PublishOutput(
             self._app,
             primary_output_dict,
@@ -95,7 +89,17 @@ class PublishHandler(object):
             selected=True,
             required=True,
         )
-        
+
+        # ---- load secondary outputs from configuration:
+
+        self._secondary_outputs = []
+
+        for output in self._app.get_setting("secondary_outputs"):
+            logger.debug("Secondary Output: %s" % (output,))
+            self._secondary_outputs.append(
+                PublishOutput(self._app, output)
+            )
+
     def show_publish_dlg(self):
         """
         Displays the publish dialog


### PR DESCRIPTION
The `post_context_change` method on the app was only rebuilding the primary output for the new context. This meant the secondary outputs were static and were only ever set up for the initial context. This change combines and centralizes the output building logic in the publish handler. This is now called by the handler initialization and the context change method. 