### PR TITLE
#46181 Uses better technique for retrieving the active doc path

### DIFF
--- a/hooks/scan_scene_tk-photoshopcc.py
+++ b/hooks/scan_scene_tk-photoshopcc.py
@@ -10,8 +10,6 @@
 
 import os
 
-import sgtk
-
 from sgtk import Hook
 from sgtk import TankError
 
@@ -57,15 +55,9 @@ class ScanSceneHook(Hook):
         items = []
         adobe = self.parent.engine.adobe
 
-        # get the main scene:
-        try:
-            doc = adobe.app.activeDocument
-        except RuntimeError:
-            raise TankError("There is no active document!")
-        
-        try:
-            scene_path = doc.fullName.fsName
-        except RuntimeError:
+        scene_path = adobe.get_active_document_path()
+
+        if not scene_path:
             raise TankError("Please save your file before publishing!")
 
         name = os.path.basename(scene_path)


### PR DESCRIPTION
This updates the publish1 code to use the adobe bridge's method for retrieving the active document path. The previous `try/except` was too specific with respect to the exception type. The new path will handle additional errors like `AttributeError`. 

This is a continuation of the work done here: https://github.com/shotgunsoftware/tk-photoshopcc/commit/d471b3a8e7eeefdc828a04036655a102af1694fa#diff-ec4ba2e3fd4512d2c469433269615506L355