### PR TITLE
 #46125: improve error handling on publish with bad template

### DIFF
--- a/python/tk_multi_publish/publish.py
+++ b/python/tk_multi_publish/publish.py
@@ -62,7 +62,12 @@ class PublishHandler(object):
         """
         The current work file template as sourced from the parent app.
         """
-        return self._app.get_template("template_work")
+        template_name = "template_work"
+        template = self._app.get_template(template_name)
+        if template is None:
+            raise TankError("Failed to retrieve the '%s' template" % (template_name))
+
+        return template
 
     def build_outputs(self):
         """

--- a/python/tk_multi_publish/publish.py
+++ b/python/tk_multi_publish/publish.py
@@ -65,7 +65,11 @@ class PublishHandler(object):
         template_name = "template_work"
         template = self._app.get_template(template_name)
         if template is None:
-            raise TankError("Failed to retrieve the '%s' template" % (template_name))
+            raise TankError(
+                "Failed to retrieve the '%s' template. This most likely means that the template"
+                "is either not defined in the project's config, or is set to an improper value."
+                % (template_name)
+            )
 
         return template
 


### PR DESCRIPTION
Raising an exception up front on trying to pull 'template_work' rather than getting an obscured error message later on the publishing process.